### PR TITLE
ClusterPathing : Fix movement bug.

### DIFF
--- a/Albion/Albion_Direct/Pathing/ClusterPathingRequest.cs
+++ b/Albion/Albion_Direct/Pathing/ClusterPathingRequest.cs
@@ -21,7 +21,7 @@ namespace Albion_Direct.Pathing
         DateTime _pauseTimer;
         //Moving fields
         private float noMovementThreshold = .0001f;
-        private const int noMovementFrames = 2;
+        private const int noMovementFrames = 30;
         Vector3[] previousLocations = new Vector3[noMovementFrames];
         private bool isMoving;
         #endregion Fields


### PR DESCRIPTION
Fixes weird behavior where the player moved in the wrong direction for a little bit and then turned around. Basically, the bot thought it was stuck and was setting a random position. Eventually the path got reset and things were OK after that. Set movement detection to 0.5 second at 60 fps.